### PR TITLE
Add tokio asyncread implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,26 @@ members = [
   "./example",
 ]
 
+[features]
+default = []
+tokio = ["dep:tokio", "dep:tokio-util", "iced_futures/tokio"]
+
 [dependencies]
 iced_native = "0.8"
-iced_futures = "0.5"
 thiserror = "1.0"
+
+[dependencies.iced_futures]
+version = "0.5"
+
+[dependencies.tokio]
+version = "1"
+optional = true
+features = ["fs"]
+
+[dependencies.tokio-util]
+version = "0.7"
+optional = true
+features = ["io", "io-util"]
 
 [dependencies.image_rs]
 package = "image"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 authors = ["tarkah <admin@tarkah.dev>"]
 
 [dependencies]
-iced_gif = { path = "../" }
-iced = { version = "0.7", features = [ "image" ] }
+iced_gif = { path = "../", features = ["tokio"]}
+iced = { version = "0.7", features = [ "image", "tokio" ] }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -40,7 +40,7 @@ impl Application for App {
 
         (
             App::default(),
-            gif::Frames::load_from_path(path, Message::Loaded),
+            gif::Frames::load_from_path_async(path).map(Message::Loaded),
         )
     }
 


### PR DESCRIPTION
Well, here you go, my first try! I've currently only implemented for tokio, because I'm lazy enough.

Also, the new `load_from_path_async`  methods signature changed as I find it more idiomatic.

The example is also updated to use async.

yes I know, we also need a async-std and smol implementation but im too lazy for that 🤓

Open to suggestions, as always!

Fixes #1