### PR TITLE
Made iced_gif::widget::gif::{Frame,Error} clonable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+**/.DS_Store

--- a/src/widget/gif.rs
+++ b/src/widget/gif.rs
@@ -21,17 +21,30 @@ use iced_futures::futures::{AsyncRead, AsyncReadExt};
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 /// Error loading or decoding a gif
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone)]
 pub enum Error {
     /// Decode error
     #[error(transparent)]
-    Image(#[from] image_rs::ImageError),
+    Image(#[from] std::sync::Arc<image_rs::ImageError>),
     /// Load error
     #[error(transparent)]
-    Io(#[from] std::io::Error),
+    Io(#[from] std::sync::Arc<std::io::Error>),
+}
+
+impl std::convert::From<image_rs::ImageError> for Error {
+    fn from(value: image_rs::ImageError) -> Self {
+        Self::Image(std::sync::Arc::new(value))
+    }
+}
+
+impl std::convert::From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(std::sync::Arc::new(value))
+    }
 }
 
 /// The frames of a decoded gif
+#[derive(Clone)]
 pub struct Frames {
     first: Frame,
     frames: Vec<Frame>,


### PR DESCRIPTION
I was experimenting with your animated gif widget the other day and noticed that I wasn't able to use it with an `enum Message {...}` that needed to implement the `Clone` trait. For instance, `iced::widget::Button<Message>` requires `Message` to implement `Clone`, such that having a `Loaded(Result<gif::Frames, gif::Error>)` variant in `enum Message` will not work, because neither of `gif::Frames` and `gif::Error` implement that trait.

So what I'm proposing here is to implement `Clone` for those types. For `gif::Frames`, using the `#[derive(Clone)]` macro suffices, but both of `git::Error`'s variants hold inner error types that aren't clonable; i.e. `std::io::Error` and `image_rs::Error`. The solution I'm proposing here is to wrap those two error types in `std::sync::Arc`.

P.-S. I'm not very familiar with GitHub pull requests, so please let me know if I did anything wrong. :)