### PR TITLE
Wrapped call to Gif decoder inside `tokio::task::spawn_blocking` when `tokio` feature flag is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /Cargo.lock
 **/.DS_Store
+.vscode
+.btasks

--- a/src/widget/gif.rs
+++ b/src/widget/gif.rs
@@ -21,17 +21,30 @@ use iced_futures::futures::{AsyncRead, AsyncReadExt};
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 /// Error loading or decoding a gif
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone)]
 pub enum Error {
     /// Decode error
     #[error(transparent)]
-    Image(#[from] image_rs::ImageError),
+    Image(#[from] std::sync::Arc<image_rs::ImageError>),
     /// Load error
     #[error(transparent)]
-    Io(#[from] std::io::Error),
+    Io(#[from] std::sync::Arc<std::io::Error>),
+}
+
+impl std::convert::From<image_rs::ImageError> for Error {
+    fn from(value: image_rs::ImageError) -> Self {
+        Self::Image(std::sync::Arc::new(value))
+    }
+}
+
+impl std::convert::From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(std::sync::Arc::new(value))
+    }
 }
 
 /// The frames of a decoded gif
+#[derive(Clone)]
 pub struct Frames {
     first: Frame,
     frames: Vec<Frame>,


### PR DESCRIPTION
This pull request is a topic branch on top of my previous, still pending pull request's <a href="https://github.com/BB-301/iced_gif/tree/clonable-frames-and-error" target="_blank">topic branch</a>.

What I am proposing here is to wrap the call made to the Gif decoder inside a `tokio::task::spawn_blocking` when the `tokio` feature flag is enabled.

To achieve that, 
1. I added the new error variant `Error::BlockingTask`, which holds `std::sync::arc<tokio::task::JoinError>`
2. I implemented `std::convert::From<tokio::task::JoinError>` for `Error`,
3. I duplicated `pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, Error>` into `pub async fn from_bytes(bytes: Vec<u8>) -> Result<Self, Error>`, and
4. I updated `pub async fn from_reader<R: AsyncRead>(reader: R) -> Result<Self, Error>` with a conditional feature check at the bottom of the function, i.e. use original version of `from_bytes` for `default` feature flag, else use the new, non-blocking, async version of `from_bytes` when the `tokio` feature flag is provided.